### PR TITLE
Fix: handle empty Fe config corner case

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import { FePluginError } from "./util";
 import { Artifacts, HardhatConfig } from "hardhat/types";
 
 extendConfig((config, userConfig) => {
-  const defaultConfig = userConfig.fe ?? { version: DEFAULT_FE_VERSION };
+  const defaultConfig = { version: DEFAULT_FE_VERSION };
   config.fe = { ...defaultConfig, ...config.fe };
 });
 

--- a/test/fixture-projects/hardhat-project-fe-defined/hardhat.config.ts
+++ b/test/fixture-projects/hardhat-project-fe-defined/hardhat.config.ts
@@ -1,0 +1,14 @@
+// We load the plugin here.
+import { HardhatUserConfig } from "hardhat/types";
+
+import "../../../src/index";
+
+const config: HardhatUserConfig = {
+  solidity: "0.7.3",
+  defaultNetwork: "hardhat",
+  fe: {
+    version: "1.0.0",
+  },
+};
+
+export default config;

--- a/test/fixture-projects/hardhat-project-fe-without-version/hardhat.config.ts
+++ b/test/fixture-projects/hardhat-project-fe-without-version/hardhat.config.ts
@@ -1,0 +1,12 @@
+// We load the plugin here.
+import { HardhatUserConfig } from "hardhat/types";
+
+import "../../../src/index";
+
+const config: HardhatUserConfig = {
+  solidity: "0.7.3",
+  defaultNetwork: "hardhat",
+  fe: {},
+};
+
+export default config;

--- a/test/project.test.ts
+++ b/test/project.test.ts
@@ -1,0 +1,27 @@
+import {useEnvironment} from "./helpers";
+import * as assert from "assert";
+import {DEFAULT_FE_VERSION} from "../src/constants";
+
+describe("Default project tests", () => {
+  describe("use fe environment without version", function () {
+    useEnvironment("hardhat-project-fe-without-version");
+    it("Set the default FE version automatically", function () {
+      // @ts-ignore
+      assert.equal(this.hre.config.fe.version, DEFAULT_FE_VERSION);
+    });
+  });
+  describe("use environment without fe settings", function () {
+    useEnvironment("hardhat-project");
+    it("Set the default FE version automatically", function () {
+      // @ts-ignore
+      assert.equal(this.hre.config.fe.version, DEFAULT_FE_VERSION);
+    });
+  });
+  describe("use environment with fe version", function () {
+    useEnvironment("hardhat-project-fe-defined");
+    it("The specified version must be used", function () {
+      // @ts-ignore
+      assert.equal(this.hre.config.fe.version, "1.0.0");
+    });
+  });
+});


### PR DESCRIPTION
1. I change how the FE configuration is merged by defining a default configuration overwrited by the custom configuration.
2. I wrote 3 tests with the version defined by the user, without the version defined by the user and with the fe property without the version inside.

Closes #9 